### PR TITLE
#53 Fix mini racer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.7.4'
+ruby '2.7.5'
 
 gem 'rails', '6.1.4.4'
 
@@ -202,8 +202,7 @@ end
 # gem 'bootstrap-sass'
 gem 'bootstrap', '~> 4'#, '>= 4.3.1'
 # gem 'less-rails'
-gem 'libv8'#, '~> 3.11.8'
-gem 'mini_racer', '~> 0.4.0'
+gem 'mini_racer'
 gem 'font-awesome-rails'
 
 # Gems used only for assets and not required

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -493,8 +493,7 @@ GEM
       rails
     kaminari-core (1.2.2)
     kgio (2.11.4)
-    libv8 (8.4.255.0)
-    libv8-node (15.14.0.1)
+    libv8-node (16.10.0.0)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -517,8 +516,8 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_portile2 (2.7.1)
-    mini_racer (0.4.0)
-      libv8-node (~> 15.14.0.0)
+    mini_racer (0.6.2)
+      libv8-node (~> 16.10.0.0)
     minitest (5.15.0)
     mjml-rails (4.7.1)
     moneta (1.0.0)
@@ -828,11 +827,10 @@ DEPENDENCIES
   jquery-ui-rails
   kaminari
   kaminari-bootstrap
-  libv8
   memcachier
   meta-tags
   mini_magick
-  mini_racer (~> 0.4.0)
+  mini_racer
   mjml-rails
   net-http-persistent
   newrelic_rpm
@@ -875,7 +873,7 @@ DEPENDENCIES
   zipruby
 
 RUBY VERSION
-   ruby 2.7.4p191
+   ruby 2.7.5p203
 
 BUNDLED WITH
-   2.1.4
+   2.3.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -494,6 +494,7 @@ GEM
     kaminari-core (1.2.2)
     kgio (2.11.4)
     libv8-node (16.10.0.0)
+    libv8-node (16.10.0.0-x86_64-linux)
     listen (3.7.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -534,6 +535,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.1)
       mini_portile2 (~> 2.7.0)
+      racc (~> 1.4)
+    nokogiri (1.13.1-x86_64-linux)
       racc (~> 1.4)
     nori (1.1.5)
     notiffany (0.1.3)
@@ -782,6 +785,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   actionpack-action_caching!


### PR DESCRIPTION
Resolves #53

- [x] Add platform to `Gemfile.lock` to keep [Heroku](https://devcenter.heroku.com/articles/bundler-version#known-upgrade-issues) happy

## Testing

1. Push this branch to staging: `git push staging fix/mini-racer:master`
1. Note the build passes