### PR TITLE
#58 Don't cancel subscription when PayPal automatic-renewal is cancelled

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -65,7 +65,7 @@ class UserMailer < ActionMailer::Base
     @issue = Issue.latest
     @issues = Issue.where(published: true).last(8).reverse
     @subscription = subscription
-    mail(:to => subscription.user.email, :subject => "Cancelled New Internationalist Subscription") do |format|
+    mail(:to => subscription.user.email, :subject => "Cancelled New Internationalist automatic-renewal") do |format|
       format.text
       format.mjml
     end

--- a/app/views/user_mailer/subscription_cancelled_via_paypal.mjml
+++ b/app/views/user_mailer/subscription_cancelled_via_paypal.mjml
@@ -1,6 +1,6 @@
 <mjml>
 	<mj-head>
-		<mj-preview>Your New Internationalist subscription has been cancelled via PayPal.</mj-preview>
+		<mj-preview>Your New Internationalist automatic-renewal has been cancelled via PayPal.</mj-preview>
 	</mj-head>
 	<mj-body background-color="#E6E6E6">
 		<mj-section padding="0">
@@ -40,7 +40,7 @@
 					font-family="helvetica"
 					font-weight="bold"
 					align="center">
-					<%= link_to "Subscription cancelled via PayPal", user_url(@user), style: 'color:inherit;' %>
+					<%= link_to "Automatic-renewal cancelled via PayPal", user_url(@user), style: 'color:inherit;' %>
 				</mj-text>
 
 				<mj-text
@@ -51,7 +51,7 @@
 					<%= @greeting %> <%= link_to @user.username, user_url(@user, :protocol => "https"), style: 'color:inherit;' %>,<br /><br />
 					Your automatic-renewal has now been cancelled via PayPal.<br /><br />
 
-					In the meantime your subscription will continue until your most recent subscription payment runs out, so you can still read magazines: <%= link_to "Magazine archive", issues_url(:protocol => "https"), style: 'color:inherit;' %><br /><br />
+					In the meantime your subscription will continue until your subscription payment runs out, so you can still read magazines: <%= link_to "Magazine archive", issues_url(:protocol => "https"), style: 'color:inherit;' %><br /><br />
 
 					<% if @user.expiry_date %>
 					Your subscription expiry date is:<br />

--- a/app/views/user_mailer/subscription_cancelled_via_paypal.text.erb
+++ b/app/views/user_mailer/subscription_cancelled_via_paypal.text.erb
@@ -1,12 +1,10 @@
-New Internationalist Subscription - Cancelled
-=============================================
+New Internationalist Subscription - Automatic-renewal cancelled
+===============================================================
 
 <%= @greeting %> <%= @user.username %>,
 Your automatic-renewal has now been cancelled via PayPal.
-Sorry to see you go! Please let us know if it's something
-we did or how we could improve this service.
 
-In the meantime your subscription will continue until your most recent subscription payment runs out, so you can still read magazines at:
+In the meantime your subscription will continue until your subscription payment runs out, so you can still read magazines at:
 <%= issues_url(:protocol => "https") %>
 
 <% if @user.expiry_date %>
@@ -15,5 +13,7 @@ Your subscription expiry date is:
 <% end %>
 
 Cheers, the NI team.
+
+PS Was there something wrong with our site or magazine? Could we improve our service? We'd love to hear the reasons why you cancelled
 
 <%= render :partial => "user_mailer/footer" %>

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -204,7 +204,7 @@ describe UserMailer, :type => :mailer do
     }
 
     it "renders the headers" do
-      expect(mail.subject).to eq("Cancelled New Internationalist Subscription")
+      expect(mail.subject).to eq("Cancelled New Internationalist automatic-renewal")
       expect(mail.to).to eq([user.email])
       expect(mail.from).to eq([ENV["DEVISE_EMAIL_ADDRESS"]])
     end


### PR DESCRIPTION
Resolves #58 

- [x] Remove `expire_recurring_subscriptions` from `PaymentNotification` `after_create`
- [x] Update `is_recurring`, `was_recurring`, and `has_cancelled_recurring` methods
- [x] Update email subject/heading to remove subscription cancelled

## Testing

1. Create a subscriber with a `paypal_profile_id` set on their subscription
1. Create a `PaymentNotification` for that user with `transaction_type == "recurring_payment_profile_cancel"`
1. Note their subscription isn't cancelled, but their profile shows auto-renewal cancelled