### PR TITLE
Upgrade to Ruby 3.2.1 and use fog-aws gem to avoid dependency issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '3.1.3'
+ruby '3.2.1'
 
 gem 'rails', '7.0.4.3'
 
@@ -251,7 +251,7 @@ gem 'carrierwave'
 
 # Using Fog for Amazon S3 image storage so it works with Heroku
 # https://github.com/jnicklas/carrierwave (see S3 section)
-gem 'fog'#, '~> 1.3.1'
+gem 'fog-aws'#, '~> 1.3.1'
 
 # RetinaImageTag for retina display support
 # https://github.com/ffaerber/retina_image_tag

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,6 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.6)
     actioncable (7.0.4.3)
       actionpack (= 7.0.4.3)
       activesupport (= 7.0.4.3)
@@ -121,9 +120,6 @@ GEM
     akami (1.2.2)
       gyoku (>= 0.4.0)
       nokogiri
-    aliyun-sdk (0.8.0)
-      nokogiri (~> 1.6)
-      rest-client (~> 2.0)
     ast (2.4.2)
     autoprefixer-rails (10.4.13.0)
       execjs (~> 2)
@@ -209,9 +205,6 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
-    dry-inflector (1.0.0)
     elasticsearch (7.13.3)
       elasticsearch-api (= 7.13.3)
       elasticsearch-transport (= 7.13.3)
@@ -261,67 +254,8 @@ GEM
     ffi (1.15.5)
     figaro (1.2.0)
       thor (>= 0.14.0, < 2)
-    fission (0.5.0)
-      CFPropertyList (~> 2.2)
     flamegraph (0.9.5)
-    fog (2.3.0)
-      fog-aliyun (>= 0.1.0)
-      fog-atmos
-      fog-aws (>= 0.6.0)
-      fog-brightbox (>= 0.4, < 2.0)
-      fog-cloudatcost (~> 0.4)
-      fog-cloudstack (~> 0.1.0)
-      fog-core (~> 2.1)
-      fog-digitalocean (>= 0.3.0)
-      fog-dnsimple (~> 2.1)
-      fog-dynect (>= 0.0.2, < 0.6.0)
-      fog-ecloud (~> 0.1)
-      fog-google (~> 1.0)
-      fog-internet-archive
-      fog-json
-      fog-local
-      fog-openstack
-      fog-ovirt
-      fog-powerdns (>= 0.1.1)
-      fog-profitbricks
-      fog-rackspace
-      fog-radosgw (>= 0.0.2)
-      fog-riakcs
-      fog-sakuracloud (>= 0.0.4)
-      fog-serverlove
-      fog-softlayer
-      fog-storm_on_demand
-      fog-terremark
-      fog-vmfusion
-      fog-voxel
-      fog-vsphere (>= 0.4.0)
-      fog-xenserver
-      fog-xml (~> 0.1.1)
-      ipaddress (~> 0.5)
-      json (~> 2.3)
-    fog-aliyun (0.4.0)
-      addressable (~> 2.8.0)
-      aliyun-sdk (~> 0.8.0)
-      fog-core
-      fog-json
-      ipaddress (~> 0.8)
-      xml-simple (~> 1.1)
-    fog-atmos (0.1.0)
-      fog-core
-      fog-xml
     fog-aws (3.18.0)
-      fog-core (~> 2.1)
-      fog-json (~> 1.1)
-      fog-xml (~> 0.1)
-    fog-brightbox (1.11.0)
-      dry-inflector
-      fog-core (>= 1.45, < 3.0)
-      fog-json
-    fog-cloudatcost (0.4.0)
-      fog-core
-      fog-json
-      ipaddress
-    fog-cloudstack (0.1.0)
       fog-core (~> 2.1)
       fog-json (~> 1.1)
       fog-xml (~> 0.1)
@@ -330,100 +264,9 @@ GEM
       excon (~> 0.71)
       formatador (~> 0.2)
       mime-types
-    fog-digitalocean (0.4.0)
-      fog-core
-      fog-json
-      fog-xml
-      ipaddress (>= 0.5)
-    fog-dnsimple (2.1.0)
-      fog-core (>= 1.38, < 3)
-      fog-json
-    fog-dynect (0.5.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-ecloud (0.3.0)
-      fog-core
-      fog-xml
-    fog-google (1.19.0)
-      fog-core (< 2.3)
-      fog-json (~> 1.2)
-      fog-xml (~> 0.1.0)
-      google-apis-compute_v1 (~> 0.14)
-      google-apis-dns_v1 (~> 0.12)
-      google-apis-iamcredentials_v1 (~> 0.6)
-      google-apis-monitoring_v3 (~> 0.12)
-      google-apis-pubsub_v1 (~> 0.7)
-      google-apis-sqladmin_v1beta4 (~> 0.13)
-      google-apis-storage_v1 (~> 0.6)
-      google-cloud-env (~> 1.2)
-    fog-internet-archive (0.0.2)
-      fog-core
-      fog-json
-      fog-xml
     fog-json (1.2.0)
       fog-core
       multi_json (~> 1.10)
-    fog-local (0.8.0)
-      fog-core (>= 1.27, < 3.0)
-    fog-openstack (1.1.0)
-      fog-core (~> 2.1)
-      fog-json (>= 1.0)
-    fog-ovirt (2.0.2)
-      activesupport
-      fog-core
-      fog-json
-      fog-xml
-      ovirt-engine-sdk (>= 4.3.1)
-    fog-powerdns (0.2.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-profitbricks (0.0.5)
-      fog-core
-      fog-xml
-      nokogiri
-    fog-rackspace (0.1.6)
-      fog-core (>= 1.35)
-      fog-json (>= 1.0)
-      fog-xml (>= 0.1)
-      ipaddress (>= 0.8)
-    fog-radosgw (0.0.5)
-      fog-core (>= 1.21.0)
-      fog-json
-      fog-xml (>= 0.0.1)
-    fog-riakcs (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-sakuracloud (1.7.5)
-      fog-core
-      fog-json
-    fog-serverlove (0.1.2)
-      fog-core
-      fog-json
-    fog-softlayer (1.1.4)
-      fog-core
-      fog-json
-    fog-storm_on_demand (0.1.1)
-      fog-core
-      fog-json
-    fog-terremark (0.1.0)
-      fog-core
-      fog-xml
-    fog-vmfusion (0.1.0)
-      fission
-      fog-core
-    fog-voxel (0.1.0)
-      fog-core
-      fog-xml
-    fog-vsphere (3.6.0)
-      fog-core
-      rbvmomi2 (~> 3.0)
-    fog-xenserver (1.0.0)
-      fog-core
-      fog-xml
-      xmlrpc
     fog-xml (0.1.4)
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
@@ -439,8 +282,6 @@ GEM
     google-api-client (0.53.0)
       google-apis-core (~> 0.1)
       google-apis-generator (~> 0.1)
-    google-apis-compute_v1 (0.64.0)
-      google-apis-core (>= 0.11.0, < 2.a)
     google-apis-core (0.11.0)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
@@ -452,26 +293,12 @@ GEM
       webrick
     google-apis-discovery_v1 (0.14.0)
       google-apis-core (>= 0.11.0, < 2.a)
-    google-apis-dns_v1 (0.31.0)
-      google-apis-core (>= 0.11.0, < 2.a)
     google-apis-generator (0.12.0)
       activesupport (>= 5.0)
       gems (~> 1.2)
       google-apis-core (>= 0.11.0, < 2.a)
       google-apis-discovery_v1 (~> 0.5)
       thor (>= 0.20, < 2.a)
-    google-apis-iamcredentials_v1 (0.17.0)
-      google-apis-core (>= 0.11.0, < 2.a)
-    google-apis-monitoring_v3 (0.42.0)
-      google-apis-core (>= 0.11.0, < 2.a)
-    google-apis-pubsub_v1 (0.35.0)
-      google-apis-core (>= 0.11.0, < 2.a)
-    google-apis-sqladmin_v1beta4 (0.45.0)
-      google-apis-core (>= 0.11.0, < 2.a)
-    google-apis-storage_v1 (0.22.0)
-      google-apis-core (>= 0.11.0, < 2.a)
-    google-cloud-env (1.6.0)
-      faraday (>= 0.17.3, < 3.0)
     google-tag-manager-rails (0.1.3)
       rails (>= 3.0.0)
     googleauth (1.3.0)
@@ -507,9 +334,6 @@ GEM
       webrick
     hkdf (0.3.0)
     http-2 (0.11.0)
-    http-accept (1.7.0)
-    http-cookie (1.0.5)
-      domain_name (~> 0.5)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
@@ -521,7 +345,6 @@ GEM
     image_processing (1.12.2)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
-    ipaddress (0.8.3)
     jquery-fileupload-rails (1.0.0)
       actionpack (>= 3.1)
       railties (>= 3.1)
@@ -598,7 +421,6 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
-    netrc (0.11.0)
     newrelic_rpm (9.0.0)
     nio4r (2.5.8)
     nokogiri (1.14.2-x86_64-darwin)
@@ -609,11 +431,8 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    optimist (3.0.1)
     orm_adapter (0.5.0)
     os (1.1.4)
-    ovirt-engine-sdk (4.4.1)
-      json (>= 1, < 3)
     pagy (6.0.2)
     parallel (1.22.1)
     parser (3.2.1.1)
@@ -680,11 +499,6 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbvmomi2 (3.6.0)
-      builder (~> 3.2)
-      json (~> 2.3)
-      nokogiri (~> 1.12, >= 1.12.5)
-      optimist (~> 3.0)
     recaptcha (5.12.3)
       json
     regexp_parser (2.7.0)
@@ -695,11 +509,6 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     retriable (3.1.2)
     rexml (3.2.5)
     rmagick (4.3.0)
@@ -823,9 +632,6 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unaccent (0.4.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
     unicorn (6.1.0)
       kgio (~> 2.6)
@@ -843,10 +649,6 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xml-simple (1.1.9)
-      rexml
-    xmlrpc (0.3.2)
-      webrick
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.7)
@@ -886,7 +688,7 @@ DEPENDENCIES
   factory_bot_rails
   figaro
   flamegraph
-  fog
+  fog-aws
   font-awesome-rails
   formtastic
   google-analytics-rails
@@ -951,7 +753,7 @@ DEPENDENCIES
   zipruby
 
 RUBY VERSION
-   ruby 3.1.3p185
+   ruby 3.2.1p31
 
 BUNDLED WITH
    2.3.26


### PR DESCRIPTION
Resolves #69

- [x] Use `fog-aws` instead of `fog` to avoid dependency issues upgrading to Ruby 3.2.1

## Testing

1. Push to newint-dev
1. Note uploads to S3 still work