### PR TITLE
Cache ip whitelist query for 1 hour

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -775,17 +775,23 @@ class User < ActiveRecord::Base
   end
 
   def self.find_by_whitelist(ip)
-    # sql one liner to handle both CIDR and IP ranges
-    query = ActiveRecord::Base.send(:sanitize_sql_array, ["with ip as (select ?::inet as value) select * from (select *, regexp_split_to_table(ip_whitelist,E',') as pattern from users) as expanded, regexp_split_to_array(expanded.pattern,E'-') as range where (expanded.pattern <> '' and expanded.pattern !~ '-' and (select value from ip) <<= expanded.pattern::inet) or (expanded.pattern ~ '-' and ((select value from ip) between range[1]::inet and range[2]::inet)) limit 1", ip])
-    begin
-      self.find_by_sql(query)
-    rescue
-      alert_text = ApplicationHelper.bad_ip_alert_text
-      logger.error alert_text
-      if not Settings.admin_alert or Settings.admin_alert == 0
-        Settings.admin_alert = 1
+    # Generate a cache key based on the IP address
+    cache_key = "user_whitelist_#{ip}"
+
+    # Fetch the cached result or execute the block if the cache key is not present
+    Rails.cache.fetch(cache_key, expires_in: 1.hour) do
+      # sql one liner to handle both CIDR and IP ranges
+      query = ActiveRecord::Base.send(:sanitize_sql_array, ["with ip as (select ?::inet as value) select * from (select *, regexp_split_to_table(ip_whitelist,E',') as pattern from users) as expanded, regexp_split_to_array(expanded.pattern,E'-') as range where (expanded.pattern <> '' and expanded.pattern !~ '-' and (select value from ip) <<= expanded.pattern::inet) or (expanded.pattern ~ '-' and ((select value from ip) between range[1]::inet and range[2]::inet)) limit 1", ip])
+      begin
+        self.find_by_sql(query)
+      rescue
+        alert_text = ApplicationHelper.bad_ip_alert_text
+        logger.error alert_text
+        if not Settings.admin_alert or Settings.admin_alert == 0
+          Settings.admin_alert = 1
+        end
+        return nil
       end
-      return nil
     end
   end
 

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -23,7 +23,8 @@
                 192.168.1.1-192.168.1.8<br />
                 192.168.1.0/24<br />
                 192.168.1.1<br />
-                Or a comma seperated list of any of the above.</p>
+                Or a comma seperated list of any of the above.<br />
+                <b>Note</b>: IP whitelist queries are cached for 1 hour.</p>
             </div>
         </div>
     <% end %>


### PR DESCRIPTION
Resolves #71

- [x] Cache institutions IP whitelist queries for 1 hour to speed up non-logged in visitor requests

## Testing

1. Add a child account to an institution
1. Add an IP whitelist to the child account
1. Note it auto-logs in
1. Remove the IP whitelist from the child account
1. Note it auto-logs in for an hour
1. Flush the rails cache `Rails.cache.clear`
1. Note no account is auto-logged-in