### PR TITLE
Upgrade rmagick

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -256,7 +256,7 @@ gem 'fog-aws'#, '~> 1.3.1'
 
 # RetinaImageTag for retina display support
 # https://github.com/ffaerber/retina_image_tag
-gem 'retina_image_tag', :git => 'https://github.com/sighmon/retina_image_tag.git', branch: 'fix/1-rmagick5'
+gem 'retina_image_tag', :git => 'https://github.com/sighmon/retina_image_tag.git'
 
 # Highlighter.js for highlighting text
 gem 'highlighter-js', :git => 'https://github.com/sighmon/highlighter.js.git'

--- a/Gemfile
+++ b/Gemfile
@@ -256,7 +256,7 @@ gem 'fog-aws'#, '~> 1.3.1'
 
 # RetinaImageTag for retina display support
 # https://github.com/ffaerber/retina_image_tag
-gem 'retina_image_tag', :git => 'https://github.com/sighmon/retina_image_tag.git'
+gem 'retina_image_tag', :git => 'https://github.com/sighmon/retina_image_tag.git', branch: 'fix/1-rmagick5'
 
 # Highlighter.js for highlighting text
 gem 'highlighter-js', :git => 'https://github.com/sighmon/highlighter.js.git'

--- a/Gemfile
+++ b/Gemfile
@@ -243,7 +243,7 @@ gem 'country_state_select'
 gem 'city-state'#, git: 'https://github.com/thecodecrate/city-state'
 
 # RMagick for image editing
-gem 'rmagick', '~> 4.3.0', :require => false
+gem 'rmagick', :require => false
 gem 'mini_magick'
 
 # CarrierWave for image uploading

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,8 @@ GIT
 
 GIT
   remote: https://github.com/sighmon/retina_image_tag.git
-  revision: 7fad00b8f012206d664568dee1ee4f90e2e8a5a9
+  revision: d6c2661cce94aab72e3cb068f866171053c751d0
+  branch: fix/1-rmagick5
   specs:
     retina_image_tag (1.0.3)
       railties (>= 3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GIT
 
 GIT
   remote: https://github.com/sighmon/retina_image_tag.git
-  revision: 7fad00b8f012206d664568dee1ee4f90e2e8a5a9
+  revision: 34b20df6f5be583aac9613f2f74a9de4aea03a40
   specs:
     retina_image_tag (1.0.3)
       railties (>= 3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,8 +34,7 @@ GIT
 
 GIT
   remote: https://github.com/sighmon/retina_image_tag.git
-  revision: d6c2661cce94aab72e3cb068f866171053c751d0
-  branch: fix/1-rmagick5
+  revision: 7fad00b8f012206d664568dee1ee4f90e2e8a5a9
   specs:
     retina_image_tag (1.0.3)
       railties (>= 3.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -464,6 +464,7 @@ GEM
       racc
     paypal-recurring (1.1.0)
     pg (1.5.4)
+    pkg-config (1.5.5)
     platform-api (3.5.0)
       heroics (~> 0.1.1)
       moneta (~> 1.0.0)
@@ -549,7 +550,8 @@ GEM
       railties (>= 5.2)
     retriable (3.1.2)
     rexml (3.2.6)
-    rmagick (4.3.0)
+    rmagick (5.3.0)
+      pkg-config (~> 1.4)
     rouge (4.2.0)
     rpush (7.0.1)
       activesupport (>= 5.2)
@@ -774,7 +776,7 @@ DEPENDENCIES
   rb-inotify
   recaptcha
   retina_image_tag!
-  rmagick (~> 4.3.0)
+  rmagick
   rpush
   rspec-activemodel-mocks
   rspec-legacy_formatters


### PR DESCRIPTION
Resolves #75

- [x] Upgrade to `rmagick` `v5` to avoid the [memory leak](https://github.com/sighmon/NI/security/dependabot/34)
- [x] Update [retina_image_tag](https://github.com/sighmon/retina_image_tag/pull/2) syntax

## Testing

1. Deploy to staging: `git push staging upgrade/75-rmagick:master`
1. Note that image uploads still work