### PR TITLE
#77 Update subscription links to point to subscribe.newint.org

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,20 +3,6 @@ class PagesController < ApplicationController
   # Cancan authorisation
   load_resource :find_by => :permalink # will use find_by_permalink!(params[:id])
   authorize_resource
-
-  # override default configuration for no_tracking pages
-  SecureHeaders::Configuration.override(:no_tracking) do |config|
-    config.csp[:child_src] = %w('self')
-    config.csp[:img_src] = %W('self' data: *.newint.com.au)
-    config.csp[:script_src] = %W('self')
-    config.csp[:style_src] = %W('self' 'unsafe-inline')
-    config.csp[:object_src] = %w('self')
-    config.csp[:connect_src] = %w('self')
-    config.csp[:form_action] = %w('self')
-    config.csp[:font_src] = %w('self')
-    config.csp[:report_uri] = %w('self')
-    config.referrer_policy = "no-referrer"
-  end
   
   # GET /pages
   # GET /pages.json
@@ -39,7 +25,6 @@ class PagesController < ApplicationController
     if @no_tracking
       # logger.info "No tracking for page #{@page.title}"
       NewRelic::Agent.ignore_transaction
-      use_secure_headers_override(:no_tracking)
     end
     @current_issue = Issue.all.sort_by(&:release).last
     @first_image = ""

--- a/app/views/issues/_email_footer.mjml
+++ b/app/views/issues/_email_footer.mjml
@@ -15,10 +15,7 @@
 					font-size="12px"
 					line-height="20px"
 					font-weight="300">
-					<%= raw(ENV["STREET_ADDRESS"]) %><br />
-					ABN 11 005 523 124<br />
-					ACN 005 523 124<br />
-					<a href="https://www.newint.com.au" style="color:inherit;">www.newint.com.au</a>
+					<a href="https://newint.org/contact" style="color:inherit;">newint.org/contact</a>
 				</mj-text>
 				<% unless local_assigns[:reason].nil? %>
 					<mj-text
@@ -45,8 +42,8 @@
 					font-size="12px"
 					line-height="20px"
 					font-weight="300">
-					<strong>Don't forget our</strong>:<br />
-					Blog: <a href="http://www.newint.com.au/blog" style="color:inherit;">newint.com.au/blog</a><br /><br />
+					<strong>Contact us</strong>:<br />
+					<a href="https://newint.org/contact" style="color:inherit;">newint.org/contact</a><br /><br />
 					<strong>On social media</strong>:<br />
 					Twitter: <a href="https://twitter.com/<%= ENV["TWITTER_NAME"] %>" style="color:inherit;">@<%= ENV["TWITTER_NAME"] %></a><br />
 					Facebook: <a href="https://facebook.com/<%= ENV["FACEBOOK_PAGE_NAME"] %>" style="color:inherit;">@<%= ENV["FACEBOOK_PAGE_NAME"] %></a><br />

--- a/app/views/issues/_email_footer.text.erb
+++ b/app/views/issues/_email_footer.text.erb
@@ -2,9 +2,7 @@
 New Internationalist Australia
 ==============================
 
-<%= strip_tags(ENV["STREET_ADDRESS"]) %>
-ABN 11 005 523 124
-ACN 005 523 124
+https://newint.org/contact
 
 Web:
 https://www.newint.com.au

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -19,9 +19,6 @@
 
 <div class="page-header<% if @page.permalink == "four-good-reasons-to-subscribe" %> page-header-center<% end %>">
   <h1><%= @page.title %></h1>
-  <% if @page.permalink == "subscribe" %>
-    <%= retina_image_tag 'paypal.png', :alt => 'Secure payments by PayPal', :title => 'Secure payments by PayPal', :size => "200x51", :class => 'subscribe-image' %>
-  <% end %>
   <% if not @page.teaser.blank? %>
     <h3><%= simple_format @page.teaser %></h3>
   <% end %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -2,28 +2,17 @@
 
   <div class="row">
     <div class="col-sm-4">
-      <!-- <div class="home-image">
-        <%= link_to retina_image_tag('utne-winner.png', :alt => 'Awards New Internationalist magazine has won', :title => 'Awards New Internationalist magazine has won', :width => 75, :height => 96), page_path("awards") %>
-      </div> -->
       <%= link_to retina_image_tag("new-internationalist-logo-300px.png", :alt => "New Internationalist - The world unspun", :title => "New Internationalist - The world unspun", width: 150, class: "brand"), root_path %>
       <% if user_signed_in? and current_user.try(:subscriber?) or current_user.try(:admin?) %>
         <p>Welcome back to the New Internationalist digital edition. Thanks for subscribing, we really appreciate it. If you have any feedback or suggestions for new features we can add, our contact details are in the footer. Enjoy reading the magazine.</p>
       <% else %>
         <p>The <b>New Internationalist</b> is an independent bi-monthly not-for-profit magazine that reports on action for global justice. We believe in putting people before profit, in climate justice, tax justice, equality, social responsibility and human rights for all.</p>
-        <div class="home-donate">
-          <p>If you like the magazine and support what we do, perhaps you'd like to donate some money to help us reach a wider audience?</p>
-          <p><form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
-            <input type="hidden" name="cmd" value="_s-xclick">
-            <input type="hidden" name="hosted_button_id" value="GSMBBM2JT2W28">
-            <button type="submit" class="btn btn-outline-secondary"><i class="fa fa-heart"></i> Donate using PayPal</button>
-          </form></p>
-        </div>
       <% end %>
     </div>
     <div class="col-sm-4">
       <h5>Site map:</h5>
       <ul>
-        <li><% if current_user.nil? %><%= link_to "Subscribe", page_path("subscribe") %><% else %><%= link_to "Subscribe", new_subscription_path %><% end %></li>
+        <li><a href="https://subscribe.newint.org">Subscribe</a></li>
         <li><%= link_to "Magazine archive", issues_path %></li>
         <li><%= link_to "Search", search_path %></li>
         <li><%= link_to "Categories", categories_path %></li>
@@ -44,7 +33,7 @@
       </ul>
       <h5>Contact us:</h5>
       <ul>
-        <li><%= raw(ENV["STREET_ADDRESS"]) %></li>
+        <li><a href="https://newint.org/contact">newint.org/contact</a></li>
       </ul>
     </div>
   </div>

--- a/app/views/subscriptions/_form.html.erb
+++ b/app/views/subscriptions/_form.html.erb
@@ -37,111 +37,14 @@
 	  </div>
 	<% end %>
 
-<% elsif @has_token %>
-
-	<%= javascript_tag do %>
-		window.purchaseID = 'user<%= try(:current_user).try(:id) %>sub<%= session[:express_purchase_subscription_duration] %><%= session[:express_autodebit] ? 'auto' : '' %>';
-		window.subscriptionPrice = <%= cents_to_dollars(session[:express_purchase_price]) %>;
-		window.subscriptionType = "<%= session[:express_purchase_subscription_duration] %> month <%= session[:express_autodebit] ? 'autodebit' : 'subscription' %>"
-		window.subscriptionNumber = "<%= session[:express_purchase_subscription_duration] %><%= session[:express_autodebit] ? 'auto' : '' %>"
-	<% end %>
-
-	<%= simple_form_for(@subscription) do |f| %>
-
-	  <dl class="dl-horizontal">
-	  	<dt>Name:</dt>
-	  	<dd><%= session[:express_first_name] %> <%= session[:express_last_name] %></dd>
-		<% if session[:express_autodebit] %>
-			<dt>Debit every:</dt>
-			<dd><%= session[:express_purchase_subscription_duration] %> months</dd>
-			<dt>Debit amount:</dt>
-			<dd>$<%= cents_to_dollars(session[:express_purchase_price]) %></dd>
-		<% else %>
-			<dt>Subscription:</dt>
-			<dd><%= session[:express_purchase_subscription_duration] %> months</dd>
-			<dt>Amount:</dt>
-			<dd>$<%= cents_to_dollars(session[:express_purchase_price]) %></dd>
-		<% end %>
-	  </dl>
-	  
-	  <div class="form-actions">
-	  	<%= f.button :submit, "Complete your purchase", :class => 'btn-success', :onclick => "sendSubscription();" %>
-	  	<% link_to 'Cancel', user_path(@user), :class => 'btn btn-outline-secondary' %>
-	  </div>
-	<% end %>
-
-	<!-- START Google Code for Digital Subscription App Conversion Page -->
-	<script type="text/javascript">
-	/* <![CDATA[ */
-	var google_conversion_id = <%= ENV["GOOGLE_CONVERSION_ID"] %>;
-	var google_conversion_language = "en";
-	var google_conversion_format = "3";
-	var google_conversion_color = "ffffff";
-	var google_conversion_label = "<%= ENV['GOOGLE_CONVERSION_LABEL'] %>";
-	var google_conversion_value = <%= cents_to_dollars(session[:express_purchase_price]) %>;
-	var google_remarketing_only = false;
-	/* ]]> */
-	</script>
-	<script type="text/javascript" src="//www.googleadservices.com/pagead/conversion.js">
-	</script>
-	<noscript>
-	<div style="display:inline;">
-	<img height="1" width="1" style="border-style:none;" alt="" src="//www.googleadservices.com/pagead/conversion/<%= ENV["GOOGLE_CONVERSION_ID"] %>/?value=<%= cents_to_dollars(session[:express_purchase_price]) %>&amp;label=<%= ENV["GOOGLE_CONVERSION_LABEL"] %>&amp;guid=ON&amp;script=0"/>
-	</div>
-	</noscript>
-	<!-- END Google Code for Digital Subscription App Conversion Page -->
-
 <% else %>
-
-	<div class="subscription-top-image">
-		<%= retina_image_tag 'devices-paper.png', :alt => 'Subscription options', :title => 'Subscription options', :size => "272x105" %>
-	</div>
-
-	<%= subscription_price_table %>
 
 	<%= simple_form_for(@subscription, :url => { :action => "express" }, :method => :get) do |f| %>
 	  <hr />
-	  <h2>Please select the subscription duration you'd like</h2>
-	  <dl class="dl-horizontal subscribe-options">
-	  	<dt><%= radio_button_tag 'duration', '3', 'false' %></dt>
-	  	<dd>3 Month Subscription</dd>
-	  	<dt><%= radio_button_tag 'duration', '6', 'false' %></dt>
-	  	<dd>6 Month Subscription</dd>
-	  	<dt><%= radio_button_tag 'duration', '12', 'true' %></dt>
-	  	<dd>12 Month Subscription</dd>
-	  </dl>
-	  <hr />
-	  <h2>Automatic debit?</h2>
-	  <p>Would you like NI to automatically debit your PayPal account until you tell us to stop?</p>
-	  <p>The debits will occur every 3, 6 or 12 months, depending on the option you chose above.</p>
-	  <dl class="dl-horizontal subscribe-options">
-	  	<dt><%= radio_button_tag 'autodebit', '1', 'false' %></dt>
-	  	<dd>Yes please!</dd>
-	  	<dt><%= radio_button_tag 'autodebit', '0', 'true' %></dt>
-	  	<dd>No thanks, just a single debit this time.</dd>
-	  </dl>
-	  <hr />
-	  <h2>Paper edition?</h2>
-	  <dl class="dl-horizontal subscribe-options">
-	  	<dt><%= radio_button_tag 'paper', '1', 'false' %></dt>
-	  	<dd>Paper and digital editions.</dd>
-	  	<dt><%= radio_button_tag 'paper', '2', 'false' %></dt>
-	  	<dd>Paper edition only.</dd>
-	  	<dt><%= radio_button_tag 'paper', '0', 'true' %></dt>
-	  	<dd>Digital edition only.</dd>
-	  </dl>
-	  <hr />
-	  <h2>Institution</h2>
-	  <p>Are you a school or institution?</p>
-	  <dl class="dl-horizontal subscribe-options">
-	  	<dt><%= radio_button_tag 'institution', '1', 'false' %></dt>
-	  	<dd>Yes, I'm ordering for a school or institution.</dd>
-	  	<dt><%= radio_button_tag 'institution', '0', 'true' %></dt>
-	  	<dd>No, this is a personal subscription.</dd>
-	  </dl>
+	  <p>Redirecting you to <a href="https://subscribe.newint.org"><strong>newint.org</strong></a> now...</p>
+	  <meta http-equiv="refresh" content="0; url=https://subscribe.newint.org" />
 
 	  <div class="form-actions">
-			<%= f.button :submit, 'Pay with PayPal Express', :class => 'btn-success', :onclick => "sendPreSubscription();" %>
 	  	<%= link_to 'Cancel', user_path(@user), :class => 'btn btn-outline-secondary' %>
 	  </div>
 	<% end %>

--- a/app/views/subscriptions/new.html.erb
+++ b/app/views/subscriptions/new.html.erb
@@ -1,7 +1,6 @@
 <div class="page-header">
-	<h1>Buy a subscription</h1>
-	<%= retina_image_tag 'paypal.png', :alt => 'Secure payments by PayPal', :title => 'Secure payments by PayPal', :size => "200x51" %>
-	<h3>All payments are made through credit cards via PayPal (PayPal account not required).<br />Special pricing is available for <a href="https://digital.newint.com.au/help#paper">school and library subscribers</a>.</h3>
+	<h1>Subscriptions</h1>
+	<h3>All subscriptions are now processed through the UK office: <a href="https://subscribe.newint.org">subscribe.newint.org</a></h3>
 </div>
 
 <%= render 'form' %>

--- a/app/views/user_mailer/_footer.text.erb
+++ b/app/views/user_mailer/_footer.text.erb
@@ -2,9 +2,7 @@
 New Internationalist Australia
 ==============================
 
-<%= strip_tags(ENV["STREET_ADDRESS"]) %>
-ABN 11 005 523 124
-ACN 005 523 124
+https://newint.org/contact
 
 Web:
 https://www.newint.com.au


### PR DESCRIPTION
- [x] Update `/subscribe` and `/subscriptions/new` to point to subscribe.newint.org
- [x] Update website footer with information for contacting the UK office
- [x] Update help page to point to the UK office

## Testing

1. Note `/subscriptions/new` redirects to subscribe.newint.org
1. Note the footer `subscribe` link has been updated